### PR TITLE
Expose the `size` parameter to `Stream#read`

### DIFF
--- a/src/Node/Stream.js
+++ b/src/Node/Stream.js
@@ -4,6 +4,8 @@
 
 // module Node.Stream
 
+exports.undefined = undefined;
+
 exports.setEncodingImpl = function(s) {
     return function(enc) {
         return function() {
@@ -105,13 +107,15 @@ exports.readImpl = function(readChunk) {
     return function(Nothing) {
         return function(Just) {
             return function(r) {
-                return function() {
-                    const v = r.read();
-                    if (v === null) {
-                        return Nothing;
-                    } else {
-                        return Just(readChunk(v));
-                    }
+                return function(s) {
+                    return function() {
+                        const v = r.read(s);
+                        if (v === null) {
+                            return Nothing;
+                        } else {
+                            return Just(readChunk(v));
+                        }
+                    };
                 };
             };
         };

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -54,11 +54,11 @@ testReads = do
   where
     testReadString = do
       sIn <- passThrough
-      v   <- readString sIn UTF8
+      v   <- readString sIn Nothing UTF8
       assert (isNothing v)
 
       onReadable sIn do
-        str <- readString sIn UTF8
+        str <- readString sIn Nothing UTF8
         assert (isJust str)
         assertEqual (fromJust str) testString
         return unit
@@ -68,11 +68,11 @@ testReads = do
 
     testReadBuf = do
       sIn <- passThrough
-      v   <- read sIn
+      v   <- read sIn Nothing
       assert (isNothing v)
 
       onReadable sIn do
-        buf <- read sIn
+        buf <- read sIn Nothing
         assert (isJust buf)
         assertEqual <$> (Buffer.toString UTF8 (fromJust buf))
                     <*> pure testString


### PR DESCRIPTION
There was an oversight in the previous PR in that we did not expose the optional size parameter: https://nodejs.org/api/stream.html#stream_readable_read_size.

I've opted for a breaking change that adds `Maybe Int` to all relevant signatures. However, we could
also add prime variants: `read'`, `readString'` and `readEither'`.