### PR TITLE
Update for PureScript 0.9.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "purescript-node-streams",
+  "version": "1.0.0",
   "license": "MIT",
   "ignore": [
     "**/.*",
@@ -12,14 +13,14 @@
     "url": "git://github.com/purescript-node/purescript-node-streams.git"
   },
   "devDependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-assert": "~0.1.1"
+    "purescript-console": "^1.0.0",
+    "purescript-assert": "^1.0.0"
   },
   "dependencies": {
-    "purescript-eff": "~0.1.1",
-    "purescript-node-buffer": "~0.2.0",
-    "purescript-prelude": "~0.1.2",
-    "purescript-either": "~0.2.3",
-    "purescript-exceptions": "~0.3.3"
+    "purescript-eff": "^1.0.0",
+    "purescript-node-buffer": "^1.0.0",
+    "purescript-prelude": "^1.0.0",
+    "purescript-either": "^1.0.0",
+    "purescript-exceptions": "^1.0.0"
   }
 }


### PR DESCRIPTION
... also, add the version to bower.json and use `^` instead of `~` for all versions.

If those other changes are not to your liking, feel free to close this and just update the bower.json yourself.