### PR TITLE
update for purescript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,15 +12,15 @@
     "url": "git://github.com/purescript-node/purescript-node-streams.git"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0",
-    "purescript-assert": "^2.0.0",
-    "purescript-partial": "^1.1.2"
+    "purescript-console": "^3.0.0",
+    "purescript-assert": "^3.0.0",
+    "purescript-partial": "^1.2.0"
   },
   "dependencies": {
-    "purescript-eff": "^2.0.0",
-    "purescript-node-buffer": "^2.0.0",
-    "purescript-prelude": "^2.1.0",
-    "purescript-either": "^2.0.0",
-    "purescript-exceptions": "^2.0.0"
+    "purescript-eff": "^3.0.0",
+    "purescript-node-buffer": "^3.0.0",
+    "purescript-prelude": "^3.0.0",
+    "purescript-either": "^3.0.0",
+    "purescript-exceptions": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "jshint src && jscs src && pulp build --censor-lib --strict",
+    "build": "jshint src && jscs src && pulp build -- --censor-lib --strict",
     "test": "pulp test"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
-    "jshint": "^2.9.3",
-    "pulp": "^9.0.1",
-    "purescript-psa": "^0.3.9",
-    "rimraf": "^2.5.4",
+    "jshint": "^2.9.4",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.0",
+    "rimraf": "^2.6.1",
     "stream-buffers": "^3.0.1"
   }
 }


### PR DESCRIPTION
This PR assumes existence of `purescript-node-buffer@^3.0.0`; there are 3 open PRs to update `node-buffer`.