### PR TITLE
fix example causing breaking builds on users of this package

### DIFF
--- a/example/Gzip.purs
+++ b/example/Gzip.purs
@@ -7,7 +7,7 @@ import Node.Stream
 import Control.Monad.Eff
 import Control.Monad.Eff.Console
 
-foreign import data GZIP :: !
+foreign import data GZIP :: Effect
 
 foreign import gzip :: forall eff. Eff (gzip :: GZIP | eff) (Duplex (gzip :: GZIP | eff))
 foreign import stdin :: forall eff. Readable () (console :: CONSOLE | eff)
@@ -15,5 +15,5 @@ foreign import stdout :: forall eff. Writable () (console :: CONSOLE | eff)
 
 main = do
   z <- gzip
-  stdin `pipe` z
+  _ <- stdin `pipe` z
   z     `pipe` stdout


### PR DESCRIPTION
If you build anything that includes "example" in downstreams, you end up getting an error from the example here...