### PR TITLE
loosen typing of two event listener functions

### DIFF
--- a/src/Node/Stream.purs
+++ b/src/Node/Stream.purs
@@ -207,14 +207,14 @@ foreign import onFinish
 -- | Listen for `close` events.
 foreign import onClose
   :: forall w eff
-   . Readable w eff
+   . Stream w eff
   -> Eff eff Unit
   -> Eff eff Unit
 
 -- | Listen for `error` events.
 foreign import onError
   :: forall w eff
-   . Readable w eff
+   . Stream w eff
   -> (Error -> Eff eff Unit)
   -> Eff eff Unit
 


### PR DESCRIPTION
The functions in question apply to events emitted by both `Readable` and `Writable` streams. They were typed so as to only apply to `Readable` streams.