### PR TITLE
Add onceDrain

### DIFF
--- a/src/Node/Stream.js
+++ b/src/Node/Stream.js
@@ -39,6 +39,14 @@ exports.onDataEitherImpl = function (readChunk) {
   };
 };
 
+exports.onceDrain = function (s) {
+  return function (f) {
+    return function () {
+      s.once("drain", f);
+    };
+  };
+};
+
 exports.onEnd = function (s) {
   return function (f) {
     return function () {

--- a/src/Node/Stream.purs
+++ b/src/Node/Stream.purs
@@ -192,6 +192,13 @@ foreign import onReadable
   -> Effect Unit
   -> Effect Unit
 
+-- | Listen for `drain` event only once.
+foreign import onceDrain
+  :: forall w
+   . Readable w
+  -> Effect Unit
+  -> Effect Unit
+
 -- | Listen for `end` events.
 foreign import onEnd
   :: forall w


### PR DESCRIPTION
Related to #15 

It seems more common to use `.once('drain', cb)` than `.on('drain', cb)`, at least on https://nodejs.org/dist/latest-v12.x/docs/api/stream.html, there are two `.once('drain', cb)` examples. Like

```js
if (!stream.write(data)) {
    stream.once('drain', cb);
  } 
```

If you prefer `.on('drain', cb)` or both, I will update.