### PR TITLE
FFI: uncurried; update naming consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ Breaking changes:
   stream # on_ dataH \buffer -> do
     ...
   ```
+- Renamed functions to better adhere to naming consistency (#50 by @JordanMartinez)
+
+  All functions that take an optional callback are now 
+  named using the following schema:
+  - no callback: `functionName`
+  - with callback: `functionName'`
+
+  Thus, the following were renamed:
+  - `write` was renamed to `write'`
+  - `writeString` was renamed to `writeString'`
+  - `end` was renamed to `end'`
+  - `destroyWithError` was renamed to `destroy'`
+
+  `write`, `writeString`, and `end` now refer to their non-callback versions.
+
 
 New features:
 - Added event handlers for `Writeable` streams (#49 by @JordanMartinez)
@@ -35,6 +50,7 @@ Other improvements:
 - Updated CI `actions/checkout` and `actions/setup-nodee` to `v3` (#48 by @JordanMartinez)
 - Format code via purs-tidy; enforce formatting via CI (#48 by @JordanMartinez)
 - Refactor tests using `passThrough` streams (#49 by @JordanMartinez)
+- Updated FFI to use uncurried functions (#50 by @JordanMartinez)
 
 ## [v7.0.0](https://github.com/purescript-node/purescript-node-streams/releases/tag/v7.0.0) - 2022-04-29
 

--- a/src/Node/Stream.js
+++ b/src/Node/Stream.js
@@ -1,8 +1,4 @@
-export function setEncodingImpl(s) {
-  return enc => () => {
-    s.setEncoding(enc);
-  };
-}
+export const setEncodingImpl = (s, enc) => s.setEncoding(enc);
 
 export const readChunkImpl = (useBuffer, useString, chunk) => {
   if (chunk instanceof Buffer) {
@@ -18,74 +14,40 @@ export const readChunkImpl = (useBuffer, useString, chunk) => {
   }
 };
 
-export function resume(s) {
-  return () => {
-    s.resume();
-  };
-}
+export const resumeImpl = (r) => r.resume();
 
-export function pause(s) {
-  return () => {
-    s.pause();
-  };
-}
+export const pauseImpl = (r) => r.pause;
 
-export function isPaused(s) {
-  return () => s.isPaused();
-}
+export const isPausedImpl = (r) => r.isPaused;
 
-export function pipe(r) {
-  return w => () => r.pipe(w);
-}
+export const pipeImpl = (r, w) => r.pipe(w);
 
-export function unpipe(r) {
-  return w => () => r.unpipe(w);
-}
+export const unpipeAllImpl = (r) => r.unpipe();
 
-export function unpipeAll(r) {
-  return () => r.unpipe();
-}
+export const unpipeImpl = (r, w) => r.unpipe(w);
 
 export const readImpl = (r) => r.read();
 
 export const readSizeImpl = (r, size) => r.read(size);
 
-export function writeImpl(w) {
-  return chunk => done => () => w.write(chunk, null, done);
-}
+export const writeImpl = (w, buf) => w.write(buf);
 
-export function writeStringImpl(w) {
-  return enc => s => done => () => w.write(s, enc, done);
-}
+export const writeCbImpl = (w, buf, cb) => w.write(buf, cb);
 
-export function cork(w) {
-  return () => w.cork();
-}
+export const writeStringImpl = (w, str, enc) => w.write(str, enc);
 
-export function uncork(w) {
-  return () => w.uncork();
-}
+export const writeStringCbImpl = (w, str, enc, cb) => w.write(str, enc, cb);
 
-export function setDefaultEncodingImpl(w) {
-  return enc => () => {
-    w.setDefaultEncoding(enc);
-  };
-}
+export const corkImpl = (w) => w.cork();
 
-export function endImpl(w) {
-  return done => () => {
-    w.end(null, null, done);
-  };
-}
+export const uncorkImpl = (w) => w.uncork();
 
-export function destroy(strm) {
-  return () => {
-    strm.destroy(null);
-  };
-}
+export const setDefaultEncodingImpl = (w, enc) => w.setDefaultEncoding(enc);
 
-export function destroyWithError(strm) {
-  return e => () => {
-    strm.destroy(e);
-  };
-}
+export const endCbImpl = (w, cb) => w.end(cb);
+
+export const endImpl = (w) => w.end();
+
+export const destroyImpl = (w) => w.destroy();
+
+export const destroyErrorImpl = (w, e) => w.destroy(e);

--- a/src/Node/Stream.purs
+++ b/src/Node/Stream.purs
@@ -41,7 +41,6 @@ module Node.Stream
   , writeString'
   , cork
   , uncork
-  , setEncoding
   , setDefaultEncoding
   , end
   , end'

--- a/src/Node/Stream.purs
+++ b/src/Node/Stream.purs
@@ -36,13 +36,17 @@ module Node.Stream
   , readEither
   , readEither'
   , write
+  , write'
   , writeString
+  , writeString'
   , cork
   , uncork
+  , setEncoding
   , setDefaultEncoding
   , end
+  , end'
   , destroy
-  , destroyWithError
+  , destroy'
   ) where
 
 import Prelude
@@ -50,13 +54,12 @@ import Prelude
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Nullable (Nullable, toMaybe)
-import Data.Nullable as N
 import Effect (Effect)
 import Effect.Exception (Error, throw)
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, mkEffectFn1, runEffectFn1, runEffectFn2, runEffectFn3)
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4, mkEffectFn1, runEffectFn1, runEffectFn2, runEffectFn3, runEffectFn4)
 import Node.Buffer (Buffer)
 import Node.Buffer as Buffer
-import Node.Encoding (Encoding)
+import Node.Encoding (Encoding, encodingToNode)
 import Node.EventEmitter (EventEmitter, EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle1, EventHandle0)
 import Unsafe.Coerce (unsafeCoerce)
@@ -235,12 +238,6 @@ readEither' r size = do
         (mkEffectFn1 (pure <<< Just <<< Left))
         c
 
-foreign import setEncodingImpl
-  :: forall w
-   . Readable w
-  -> String
-  -> Effect Unit
-
 -- | Set the encoding used to read chunks as strings from the stream. This
 -- | function may be useful when you are passing a readable stream to some other
 -- | JavaScript library, which already expects an encoding to be set.
@@ -252,7 +249,9 @@ setEncoding
    . Readable w
   -> Encoding
   -> Effect Unit
-setEncoding r enc = setEncodingImpl r (show enc)
+setEncoding r enc = runEffectFn2 setEncodingImpl r (show enc)
+
+foreign import setEncodingImpl :: forall w. EffectFn2 (Readable w) String Unit
 
 closeH :: forall rw. EventHandle0 (Stream rw)
 closeH = EventHandle "close" identity
@@ -285,79 +284,72 @@ endH :: forall w. EventHandle0 (Readable w)
 endH = EventHandle "end" identity
 
 -- | Resume reading from the stream.
-foreign import resume :: forall w. Readable w -> Effect Unit
+resume :: forall w. Readable w -> Effect Unit
+resume r = runEffectFn1 resumeImpl r
+
+foreign import resumeImpl :: forall w. EffectFn1 (Readable w) (Unit)
 
 -- | Pause reading from the stream.
-foreign import pause :: forall w. Readable w -> Effect Unit
+pause :: forall w. Readable w -> Effect Unit
+pause r = runEffectFn1 pauseImpl r
+
+foreign import pauseImpl :: forall w. EffectFn1 (Readable w) (Unit)
 
 -- | Check whether or not a stream is paused for reading.
-foreign import isPaused :: forall w. Readable w -> Effect Boolean
+isPaused :: forall w. Readable w -> Effect Boolean
+isPaused r = runEffectFn1 isPausedImpl r
+
+foreign import isPausedImpl :: forall w. EffectFn1 (Readable w) (Boolean)
 
 -- | Read chunks from a readable stream and write them to a writable stream.
-foreign import pipe
-  :: forall r w
-   . Readable w
-  -> Writable r
-  -> Effect (Writable r)
+pipe :: forall w r. Readable w -> Writable r -> Effect Unit
+pipe r w = runEffectFn2 pipeImpl r w
+
+foreign import pipeImpl :: forall w r. EffectFn2 (Readable w) (Writable r) (Unit)
 
 -- | Detach a Writable stream previously attached using `pipe`.
-foreign import unpipe
-  :: forall r w
-   . Readable w
-  -> Writable r
-  -> Effect Unit
+unpipe :: forall w r. Readable w -> Writable r -> Effect Unit
+unpipe r w = runEffectFn2 unpipeImpl r w
+
+foreign import unpipeImpl :: forall w r. EffectFn2 (Readable w) (Writable r) (Unit)
 
 -- | Detach all Writable streams previously attached using `pipe`.
-foreign import unpipeAll
-  :: forall w
-   . Readable w
-  -> Effect Unit
+unpipeAll :: forall w. Readable w -> Effect Unit
+unpipeAll r = runEffectFn1 unpipeAllImpl r
 
-foreign import writeImpl
-  :: forall r
-   . Writable r
-  -> Buffer
-  -> EffectFn1 (N.Nullable Error) Unit
-  -> Effect Boolean
+foreign import unpipeAllImpl :: forall w. EffectFn1 (Readable w) (Unit)
 
--- | Write a Buffer to a writable stream.
-write
-  :: forall r
-   . Writable r
-  -> Buffer
-  -> (Maybe Error -> Effect Unit)
-  -> Effect Boolean
-write w b cb = writeImpl w b $ mkEffectFn1 (cb <<< N.toMaybe)
+write :: forall r. Writable r -> Buffer -> Effect Boolean
+write w b = runEffectFn2 writeImpl w b
 
-foreign import writeStringImpl
-  :: forall r
-   . Writable r
-  -> String
-  -> String
-  -> EffectFn1 (N.Nullable Error) Unit
-  -> Effect Boolean
+foreign import writeImpl :: forall r a. EffectFn2 (Writable r) (Buffer) (a)
 
--- | Write a string in the specified encoding to a writable stream.
-writeString
-  :: forall r
-   . Writable r
-  -> Encoding
-  -> String
-  -> (Maybe Error -> Effect Unit)
-  -> Effect Boolean
-writeString w enc s cb = writeStringImpl w (show enc) s $ mkEffectFn1 (cb <<< N.toMaybe)
+write' :: forall r. Writable r -> Buffer -> (Maybe Error -> Effect Unit) -> Effect Boolean
+write' w b cb = runEffectFn3 writeCbImpl w b $ mkEffectFn1 \err -> cb (toMaybe err)
+
+foreign import writeCbImpl :: forall r a. EffectFn3 (Writable r) (Buffer) (EffectFn1 (Nullable Error) Unit) (a)
+
+writeString :: forall r. Writable r -> Encoding -> String -> Effect Boolean
+writeString w enc str = runEffectFn3 writeStringImpl w str (encodingToNode enc)
+
+foreign import writeStringImpl :: forall r a. EffectFn3 (Writable r) (String) (String) (a)
+
+writeString' :: forall r. Writable r -> Encoding -> String -> (Maybe Error -> Effect Unit) -> Effect Boolean
+writeString' w enc str cb = runEffectFn4 writeStringCbImpl w str (encodingToNode enc) $ mkEffectFn1 \err -> cb (toMaybe err)
+
+foreign import writeStringCbImpl :: forall r a. EffectFn4 (Writable r) (String) (String) (EffectFn1 (Nullable Error) Unit) (a)
 
 -- | Force buffering of writes.
-foreign import cork :: forall r. Writable r -> Effect Unit
+cork :: forall r. Writable r -> Effect Unit
+cork s = runEffectFn1 corkImpl s
+
+foreign import corkImpl :: forall r. EffectFn1 (Writable r) (Unit)
 
 -- | Flush buffered data.
-foreign import uncork :: forall r. Writable r -> Effect Unit
+uncork :: forall r. Writable r -> Effect Unit
+uncork w = runEffectFn1 uncorkImpl w
 
-foreign import setDefaultEncodingImpl
-  :: forall r
-   . Writable r
-  -> String
-  -> Effect Unit
+foreign import uncorkImpl :: forall r. EffectFn1 (Writable r) (Unit)
 
 -- | Set the default encoding used to write strings to the stream. This function
 -- | is useful when you are passing a writable stream to some other JavaScript
@@ -369,35 +361,28 @@ setDefaultEncoding
    . Writable r
   -> Encoding
   -> Effect Unit
-setDefaultEncoding r enc = setDefaultEncodingImpl r (show enc)
+setDefaultEncoding r enc = runEffectFn2 setDefaultEncodingImpl r (show enc)
 
-foreign import endImpl
-  :: forall r
-   . Writable r
-  -> EffectFn1 (N.Nullable Error) Unit
-  -> Effect Unit
+foreign import setDefaultEncodingImpl :: forall r. EffectFn2 (Writable r) String Unit
 
 -- | End writing data to the stream.
-end
-  :: forall r
-   . Writable r
-  -> (Maybe Error -> Effect Unit)
-  -> Effect Unit
-end w cb = endImpl w $ mkEffectFn1 (cb <<< N.toMaybe)
+end :: forall r. Writable r -> Effect Unit
+end w = runEffectFn1 endImpl w
 
--- | Destroy the stream. It will release any internal resources.
---
--- Added in node 8.0.
-foreign import destroy
-  :: forall r
-   . Stream r
-  -> Effect Unit
+foreign import endImpl :: forall r. EffectFn1 (Writable r) (Unit)
 
--- | Destroy the stream and emit 'error'.
---
--- Added in node 8.0.
-foreign import destroyWithError
-  :: forall r
-   . Stream r
-  -> Error
-  -> Effect Unit
+end' :: forall r. Writable r -> (Maybe Error -> Effect Unit) -> Effect Unit
+end' w cb = runEffectFn2 endCbImpl w $ mkEffectFn1 \err -> cb (toMaybe err)
+
+foreign import endCbImpl :: forall r. EffectFn2 (Writable r) (EffectFn1 (Nullable Error) Unit) (Unit)
+
+destroy :: forall r. Stream r -> Effect Unit
+destroy w = runEffectFn1 destroyImpl w
+
+foreign import destroyImpl :: forall r. EffectFn1 (Stream r) (Unit)
+
+destroy' :: forall r. Stream r -> Error -> Effect Unit
+destroy' w e = runEffectFn2 destroyErrorImpl w e
+
+foreign import destroyErrorImpl :: forall r. EffectFn2 (Stream r) (Error) Unit
+


### PR DESCRIPTION
**Description of the change**

Updates FFI to uncurried functions.

Updates naming convention for functions that have an optional callback.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
