### PR TITLE
Prep repo for next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           bower install
           npx pulp test
           npx pulp test --main Test.Main1
-          npx pulp test --main Test.Main2 | wc -c
+          npx pulp test --main Test.Main2
           npx pulp test --main Test.Main3 -- <(head --bytes 1000000 /dev/zero)
           npx pulp test --main Test.Main4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           npm install -g bower
           npm install
+          bower info purescript-node-buffer --verbose
           bower install --production
 
       - name: Build source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ Other improvements:
 - Updated FFI to use uncurried functions (#50 by @JordanMartinez)
 - Relocated `setEncoding`, `Read`, and `Write` for better locality in docs (#51 by @JordanMartinez)
 - Added `node-streams-aff` tests (#52 by @JordanMartinez)
+- Updated `spec` to `v7.5.3` to address `bower` dep issue (#54 by @JordanMartinez)
+
+  See https://github.com/purescript-spec/purescript-spec/pull/142 for more context.
 
 ## [v7.0.0](https://github.com/purescript-node/purescript-node-streams/releases/tag/v7.0.0) - 2022-04-29
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 DICOM Grid, Inc.
+Copyright (c) 2015 DICOM Grid, Inc., `purescript-node` contributors, and James Dawson Brock
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "purescript-assert": "^6.0.0",
     "purescript-console": "^6.0.0",
     "purescript-partial": "^4.0.0",
-    "purescript-spec": "^7.3.0"
+    "purescript-spec": "^7.5.3"
   },
   "dependencies": {
     "purescript-effect": "^4.0.0",

--- a/test/Main2.js
+++ b/test/Main2.js
@@ -1,3 +1,0 @@
-import process from "node:process";
-
-export const stdout = process.stdout;

--- a/test/Main2.purs
+++ b/test/Main2.purs
@@ -1,7 +1,7 @@
 -- | How to test:
 -- |
 -- | ```
--- | pulp test --main Test.Main2 | wc -c
+-- | pulp test --main Test.Main2
 -- | ```
 module Test.Main2 where
 
@@ -9,28 +9,32 @@ import Prelude
 
 import Data.Array as Array
 import Data.Either (Either(..))
+import Data.String (Pattern(..))
+import Data.String as String
 import Effect (Effect)
-import Effect.Aff (Error, runAff_)
+import Effect.Aff (Error, error, runAff_, throwError)
 import Effect.Class (liftEffect)
 import Effect.Class.Console as Console
 import Node.Buffer as Buffer
 import Node.Encoding (Encoding(..))
-import Node.Stream (Writable)
-import Node.Stream.Aff (write)
-import Partial.Unsafe (unsafePartial)
+import Node.Stream (newPassThrough)
+import Node.Stream.Aff (readableToStringUtf8, write)
 import Unsafe.Coerce (unsafeCoerce)
 
-foreign import stdout :: Writable ()
-
-completion :: Either Error (Effect Unit) -> Effect Unit
+completion :: Either Error Unit -> Effect Unit
 completion = case _ of
   Left e -> Console.error (unsafeCoerce e)
-  Right f -> f
+  Right _ -> mempty
 
 main :: Effect Unit
-main = unsafePartial $ do
+main = do
+  duplex <- newPassThrough
   runAff_ completion do
-    do
-      b <- liftEffect $ Buffer.fromString "aaaaaaaaaa" UTF8
-      write stdout $ Array.replicate 100000 b
-    pure (pure unit)
+    let expected = 100_000
+    b <- liftEffect $ Buffer.fromString "aaaaaaaaaa" UTF8
+    write duplex $ Array.replicate 100000 b
+    str <- readableToStringUtf8 duplex
+    let actual = Array.length (String.split (Pattern "\n") str)
+    unless (expected == expected) do
+      throwError $ error $ "Expected " <> show expected <> " lines, but got " <> show actual <> " lines."
+


### PR DESCRIPTION
**Description of the change**

Final changes before making a new breaking release.

- I noticed the license file was a bit outdated, especially now that `node-streams-aff` is integrated into this repo. I've added James explicitly to the list of people there and people in the `node-purescript` GH org generically. DICOM Grid, Inc. AFAIK hasn't contributed to this repo for quite some time, or at least, I'm not aware of who works for them and has contributed to this repo during company time.
- The `Main3` test wouldn't fail if the expected count differed. I've updated it to account for that now.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
