### PR TITLE
Relax aff dependency version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "unstable"
+          purescript: "latest"
           purs-tidy: "latest"
           spago: "unstable"
 

--- a/spago.lock
+++ b/spago.lock
@@ -1,744 +1,881 @@
-workspace:
-  packages:
-    node-streams:
-      path: ./
-      core:
-        dependencies:
-          - aff: ">=8.0.0 <9.0.0"
-          - effect: ">=4.0.0 <5.0.0"
-          - either: ">=6.0.0 <7.0.0"
-          - exceptions: ">=6.0.0 <7.0.0"
-          - node-buffer: ">=9.0.0 <10.0.0"
-          - node-event-emitter: ">=3.0.0 <4.0.0"
-          - nullable: ">=6.0.0 <7.0.0"
-          - prelude: ">=6.0.0 <7.0.0"
-        build_plan:
-          - aff
-          - arraybuffer-types
-          - arrays
-          - bifunctors
-          - const
-          - contravariant
-          - control
-          - datetime
-          - distributive
-          - effect
-          - either
-          - enums
-          - exceptions
-          - exists
-          - foldable-traversable
-          - functions
-          - functors
-          - gen
-          - identity
-          - integers
-          - invariant
-          - lazy
-          - lists
-          - maybe
-          - newtype
-          - node-buffer
-          - node-event-emitter
-          - nonempty
-          - nullable
-          - numbers
-          - ordered-collections
-          - orders
-          - parallel
-          - partial
-          - prelude
-          - profunctor
-          - refs
-          - safe-coerce
-          - st
-          - tailrec
-          - transformers
-          - tuples
-          - type-equality
-          - unfoldable
-          - unsafe-coerce
-      test:
-        dependencies:
-          - assert
-          - console
-          - partial
-          - spec
-        build_plan:
-          - aff
-          - ansi
-          - arrays
-          - assert
-          - avar
-          - bifunctors
-          - catenable-lists
-          - console
-          - const
-          - contravariant
-          - control
-          - datetime
-          - distributive
-          - effect
-          - either
-          - enums
-          - exceptions
-          - exists
-          - foldable-traversable
-          - fork
-          - free
-          - functions
-          - functors
-          - gen
-          - identity
-          - integers
-          - invariant
-          - lazy
-          - lists
-          - maybe
-          - mmorph
-          - newtype
-          - nonempty
-          - now
-          - numbers
-          - ordered-collections
-          - orders
-          - parallel
-          - partial
-          - pipes
-          - prelude
-          - profunctor
-          - refs
-          - safe-coerce
-          - spec
-          - st
-          - strings
-          - tailrec
-          - transformers
-          - tuples
-          - type-equality
-          - unfoldable
-          - unsafe-coerce
-  extra_packages: {}
-packages:
-  aff:
-    type: registry
-    version: 8.0.0
-    integrity: sha256-5MmdI4+0RHBtSBy+YlU3/Cq4R5W2ih3OaRedJIrVHdk=
-    dependencies:
-      - bifunctors
-      - control
-      - datetime
-      - effect
-      - either
-      - exceptions
-      - foldable-traversable
-      - functions
-      - maybe
-      - newtype
-      - parallel
-      - prelude
-      - refs
-      - tailrec
-      - transformers
-      - unsafe-coerce
-  ansi:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=
-    dependencies:
-      - foldable-traversable
-      - lists
-      - strings
-  arraybuffer-types:
-    type: registry
-    version: 3.0.2
-    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
-    dependencies: []
-  arrays:
-    type: registry
-    version: 7.3.0
-    integrity: sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=
-    dependencies:
-      - bifunctors
-      - control
-      - foldable-traversable
-      - functions
-      - maybe
-      - nonempty
-      - partial
-      - prelude
-      - safe-coerce
-      - st
-      - tailrec
-      - tuples
-      - unfoldable
-      - unsafe-coerce
-  assert:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-hCSYcCw9kj3qujoDcriWhCdmrpPZoguSPDZhEMnTl3A=
-    dependencies:
-      - console
-      - effect
-      - prelude
-  avar:
-    type: registry
-    version: 5.0.0
-    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
-    dependencies:
-      - aff
-      - effect
-      - either
-      - exceptions
-      - functions
-      - maybe
-  bifunctors:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
-    dependencies:
-      - const
-      - either
-      - newtype
-      - prelude
-      - tuples
-  catenable-lists:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
-    dependencies:
-      - control
-      - foldable-traversable
-      - lists
-      - maybe
-      - prelude
-      - tuples
-      - unfoldable
-  console:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=
-    dependencies:
-      - effect
-      - prelude
-  const:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
-    dependencies:
-      - invariant
-      - newtype
-      - prelude
-  contravariant:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
-    dependencies:
-      - const
-      - either
-      - newtype
-      - prelude
-      - tuples
-  control:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
-    dependencies:
-      - newtype
-      - prelude
-  datetime:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
-    dependencies:
-      - bifunctors
-      - control
-      - either
-      - enums
-      - foldable-traversable
-      - functions
-      - gen
-      - integers
-      - lists
-      - maybe
-      - newtype
-      - numbers
-      - ordered-collections
-      - partial
-      - prelude
-      - tuples
-  distributive:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
-    dependencies:
-      - identity
-      - newtype
-      - prelude
-      - tuples
-      - type-equality
-  effect:
-    type: registry
-    version: 4.0.0
-    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
-    dependencies:
-      - prelude
-  either:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
-    dependencies:
-      - control
-      - invariant
-      - maybe
-      - prelude
-  enums:
-    type: registry
-    version: 6.0.1
-    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
-    dependencies:
-      - control
-      - either
-      - gen
-      - maybe
-      - newtype
-      - nonempty
-      - partial
-      - prelude
-      - tuples
-      - unfoldable
-  exceptions:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-K0T89IHtF3vBY7eSAO7eDOqSb2J9kZGAcDN5+IKsF8E=
-    dependencies:
-      - effect
-      - either
-      - maybe
-      - prelude
-  exists:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
-    dependencies:
-      - unsafe-coerce
-  foldable-traversable:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
-    dependencies:
-      - bifunctors
-      - const
-      - control
-      - either
-      - functors
-      - identity
-      - maybe
-      - newtype
-      - orders
-      - prelude
-      - tuples
-  fork:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-X7u0SuCvFbLbzuNEKLBNuWjmcroqMqit4xEzpQwAP7E=
-    dependencies:
-      - aff
-  free:
-    type: registry
-    version: 7.1.0
-    integrity: sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=
-    dependencies:
-      - catenable-lists
-      - control
-      - distributive
-      - either
-      - exists
-      - foldable-traversable
-      - invariant
-      - lazy
-      - maybe
-      - prelude
-      - tailrec
-      - transformers
-      - tuples
-      - unsafe-coerce
-  functions:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
-    dependencies:
-      - prelude
-  functors:
-    type: registry
-    version: 5.0.0
-    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
-    dependencies:
-      - bifunctors
-      - const
-      - contravariant
-      - control
-      - distributive
-      - either
-      - invariant
-      - maybe
-      - newtype
-      - prelude
-      - profunctor
-      - tuples
-      - unsafe-coerce
-  gen:
-    type: registry
-    version: 4.0.0
-    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
-    dependencies:
-      - either
-      - foldable-traversable
-      - identity
-      - maybe
-      - newtype
-      - nonempty
-      - prelude
-      - tailrec
-      - tuples
-      - unfoldable
-  identity:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
-    dependencies:
-      - control
-      - invariant
-      - newtype
-      - prelude
-  integers:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
-    dependencies:
-      - maybe
-      - numbers
-      - prelude
-  invariant:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
-    dependencies:
-      - control
-      - prelude
-  lazy:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
-    dependencies:
-      - control
-      - foldable-traversable
-      - invariant
-      - prelude
-  lists:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
-    dependencies:
-      - bifunctors
-      - control
-      - foldable-traversable
-      - lazy
-      - maybe
-      - newtype
-      - nonempty
-      - partial
-      - prelude
-      - tailrec
-      - tuples
-      - unfoldable
-  maybe:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
-    dependencies:
-      - control
-      - invariant
-      - newtype
-      - prelude
-  mmorph:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-urZlZNNqGeQFe5D/ClHlR8QgGBNHTMFPtJ5S5IpflTQ=
-    dependencies:
-      - free
-      - functors
-      - transformers
-  newtype:
-    type: registry
-    version: 5.0.0
-    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
-    dependencies:
-      - prelude
-      - safe-coerce
-  node-buffer:
-    type: registry
-    version: 9.0.0
-    integrity: sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=
-    dependencies:
-      - arraybuffer-types
-      - effect
-      - maybe
-      - nullable
-      - st
-      - unsafe-coerce
-  node-event-emitter:
-    type: registry
-    version: 3.0.0
-    integrity: sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=
-    dependencies:
-      - effect
-      - either
-      - functions
-      - maybe
-      - nullable
-      - prelude
-      - unsafe-coerce
-  nonempty:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
-    dependencies:
-      - control
-      - foldable-traversable
-      - maybe
-      - prelude
-      - tuples
-      - unfoldable
-  now:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
-    dependencies:
-      - datetime
-      - effect
-  nullable:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
-    dependencies:
-      - effect
-      - functions
-      - maybe
-  numbers:
-    type: registry
-    version: 9.0.1
-    integrity: sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=
-    dependencies:
-      - functions
-      - maybe
-  ordered-collections:
-    type: registry
-    version: 3.2.0
-    integrity: sha256-o9jqsj5rpJmMdoe/zyufWHFjYYFTTsJpgcuCnqCO6PM=
-    dependencies:
-      - arrays
-      - foldable-traversable
-      - gen
-      - lists
-      - maybe
-      - partial
-      - prelude
-      - st
-      - tailrec
-      - tuples
-      - unfoldable
-  orders:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
-    dependencies:
-      - newtype
-      - prelude
-  parallel:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
-    dependencies:
-      - control
-      - effect
-      - either
-      - foldable-traversable
-      - functors
-      - maybe
-      - newtype
-      - prelude
-      - profunctor
-      - refs
-      - transformers
-  partial:
-    type: registry
-    version: 4.0.0
-    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
-    dependencies: []
-  pipes:
-    type: registry
-    version: 8.0.0
-    integrity: sha256-kvfqGM4cPA/wCcBHbp5psouFw5dZGvku2462x7ZBwSY=
-    dependencies:
-      - aff
-      - lists
-      - mmorph
-      - prelude
-      - tailrec
-      - transformers
-      - tuples
-  prelude:
-    type: registry
-    version: 6.0.1
-    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
-    dependencies: []
-  profunctor:
-    type: registry
-    version: 6.0.1
-    integrity: sha256-E58hSYdJvF2Qjf9dnWLPlJKh2Z2fLfFLkQoYi16vsFk=
-    dependencies:
-      - control
-      - distributive
-      - either
-      - exists
-      - invariant
-      - newtype
-      - prelude
-      - tuples
-  refs:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
-    dependencies:
-      - effect
-      - prelude
-  safe-coerce:
-    type: registry
-    version: 2.0.0
-    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
-    dependencies:
-      - unsafe-coerce
-  spec:
-    type: registry
-    version: 8.0.0
-    integrity: sha256-Yn7MhDai1YULlQF45+9FTOTf2rcjoda1Jf2IrEFCoeg=
-    dependencies:
-      - aff
-      - ansi
-      - arrays
-      - avar
-      - bifunctors
-      - control
-      - datetime
-      - effect
-      - either
-      - exceptions
-      - foldable-traversable
-      - fork
-      - identity
-      - integers
-      - lists
-      - maybe
-      - newtype
-      - now
-      - ordered-collections
-      - parallel
-      - pipes
-      - prelude
-      - refs
-      - strings
-      - tailrec
-      - transformers
-      - tuples
-  st:
-    type: registry
-    version: 6.2.0
-    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
-    dependencies:
-      - partial
-      - prelude
-      - tailrec
-      - unsafe-coerce
-  strings:
-    type: registry
-    version: 6.0.1
-    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
-    dependencies:
-      - arrays
-      - control
-      - either
-      - enums
-      - foldable-traversable
-      - gen
-      - integers
-      - maybe
-      - newtype
-      - nonempty
-      - partial
-      - prelude
-      - tailrec
-      - tuples
-      - unfoldable
-      - unsafe-coerce
-  tailrec:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
-    dependencies:
-      - bifunctors
-      - effect
-      - either
-      - identity
-      - maybe
-      - partial
-      - prelude
-      - refs
-  transformers:
-    type: registry
-    version: 6.1.0
-    integrity: sha256-3Bm+Z6tsC/paG888XkywDngJ2JMos+JfOhRlkVfb7gI=
-    dependencies:
-      - control
-      - distributive
-      - effect
-      - either
-      - exceptions
-      - foldable-traversable
-      - identity
-      - lazy
-      - maybe
-      - newtype
-      - prelude
-      - st
-      - tailrec
-      - tuples
-      - unfoldable
-  tuples:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
-    dependencies:
-      - control
-      - invariant
-      - prelude
-  type-equality:
-    type: registry
-    version: 4.0.1
-    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
-    dependencies: []
-  unfoldable:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
-    dependencies:
-      - foldable-traversable
-      - maybe
-      - partial
-      - prelude
-      - tuples
-  unsafe-coerce:
-    type: registry
-    version: 6.0.0
-    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
-    dependencies: []
+{
+  "workspace": {
+    "packages": {
+      "node-streams": {
+        "path": "./",
+        "core": {
+          "dependencies": [
+            {
+              "aff": ">=7.0.0 <9.0.0"
+            },
+            {
+              "effect": ">=4.0.0 <5.0.0"
+            },
+            {
+              "either": ">=6.0.0 <7.0.0"
+            },
+            {
+              "exceptions": ">=6.0.0 <7.0.0"
+            },
+            {
+              "node-buffer": ">=9.0.0 <10.0.0"
+            },
+            {
+              "node-event-emitter": ">=3.0.0 <4.0.0"
+            },
+            {
+              "nullable": ">=6.0.0 <7.0.0"
+            },
+            {
+              "prelude": ">=6.0.0 <7.0.0"
+            }
+          ],
+          "build_plan": [
+            "aff",
+            "arraybuffer-types",
+            "arrays",
+            "bifunctors",
+            "const",
+            "contravariant",
+            "control",
+            "datetime",
+            "distributive",
+            "effect",
+            "either",
+            "enums",
+            "exceptions",
+            "exists",
+            "foldable-traversable",
+            "functions",
+            "functors",
+            "gen",
+            "identity",
+            "integers",
+            "invariant",
+            "lazy",
+            "lists",
+            "maybe",
+            "newtype",
+            "node-buffer",
+            "node-event-emitter",
+            "nonempty",
+            "nullable",
+            "numbers",
+            "ordered-collections",
+            "orders",
+            "parallel",
+            "partial",
+            "prelude",
+            "profunctor",
+            "refs",
+            "safe-coerce",
+            "st",
+            "tailrec",
+            "transformers",
+            "tuples",
+            "type-equality",
+            "unfoldable",
+            "unsafe-coerce"
+          ]
+        },
+        "test": {
+          "dependencies": [
+            "assert",
+            "console",
+            "partial",
+            "spec"
+          ],
+          "build_plan": [
+            "aff",
+            "ansi",
+            "arrays",
+            "assert",
+            "avar",
+            "bifunctors",
+            "catenable-lists",
+            "console",
+            "const",
+            "contravariant",
+            "control",
+            "datetime",
+            "distributive",
+            "effect",
+            "either",
+            "enums",
+            "exceptions",
+            "exists",
+            "foldable-traversable",
+            "fork",
+            "free",
+            "functions",
+            "functors",
+            "gen",
+            "identity",
+            "integers",
+            "invariant",
+            "lazy",
+            "lists",
+            "maybe",
+            "mmorph",
+            "newtype",
+            "nonempty",
+            "now",
+            "numbers",
+            "ordered-collections",
+            "orders",
+            "parallel",
+            "partial",
+            "pipes",
+            "prelude",
+            "profunctor",
+            "refs",
+            "safe-coerce",
+            "spec",
+            "st",
+            "strings",
+            "tailrec",
+            "transformers",
+            "tuples",
+            "type-equality",
+            "unfoldable",
+            "unsafe-coerce"
+          ]
+        }
+      }
+    },
+    "extra_packages": {}
+  },
+  "packages": {
+    "aff": {
+      "type": "registry",
+      "version": "8.0.0",
+      "integrity": "sha256-5MmdI4+0RHBtSBy+YlU3/Cq4R5W2ih3OaRedJIrVHdk=",
+      "dependencies": [
+        "bifunctors",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "exceptions",
+        "foldable-traversable",
+        "functions",
+        "maybe",
+        "newtype",
+        "parallel",
+        "prelude",
+        "refs",
+        "tailrec",
+        "transformers",
+        "unsafe-coerce"
+      ]
+    },
+    "ansi": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=",
+      "dependencies": [
+        "foldable-traversable",
+        "lists",
+        "strings"
+      ]
+    },
+    "arraybuffer-types": {
+      "type": "registry",
+      "version": "3.0.2",
+      "integrity": "sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=",
+      "dependencies": []
+    },
+    "arrays": {
+      "type": "registry",
+      "version": "7.3.0",
+      "integrity": "sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=",
+      "dependencies": [
+        "bifunctors",
+        "control",
+        "foldable-traversable",
+        "functions",
+        "maybe",
+        "nonempty",
+        "partial",
+        "prelude",
+        "safe-coerce",
+        "st",
+        "tailrec",
+        "tuples",
+        "unfoldable",
+        "unsafe-coerce"
+      ]
+    },
+    "assert": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-hCSYcCw9kj3qujoDcriWhCdmrpPZoguSPDZhEMnTl3A=",
+      "dependencies": [
+        "console",
+        "effect",
+        "prelude"
+      ]
+    },
+    "avar": {
+      "type": "registry",
+      "version": "5.0.0",
+      "integrity": "sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=",
+      "dependencies": [
+        "aff",
+        "effect",
+        "either",
+        "exceptions",
+        "functions",
+        "maybe"
+      ]
+    },
+    "bifunctors": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=",
+      "dependencies": [
+        "const",
+        "either",
+        "newtype",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "catenable-lists": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=",
+      "dependencies": [
+        "control",
+        "foldable-traversable",
+        "lists",
+        "maybe",
+        "prelude",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "console": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-CxmAzjgyuGDmt9FZW51VhV6rBPwR6o0YeKUzA9rSzcM=",
+      "dependencies": [
+        "effect",
+        "prelude"
+      ]
+    },
+    "const": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=",
+      "dependencies": [
+        "invariant",
+        "newtype",
+        "prelude"
+      ]
+    },
+    "contravariant": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=",
+      "dependencies": [
+        "const",
+        "either",
+        "newtype",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "control": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=",
+      "dependencies": [
+        "newtype",
+        "prelude"
+      ]
+    },
+    "datetime": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=",
+      "dependencies": [
+        "bifunctors",
+        "control",
+        "either",
+        "enums",
+        "foldable-traversable",
+        "functions",
+        "gen",
+        "integers",
+        "lists",
+        "maybe",
+        "newtype",
+        "numbers",
+        "ordered-collections",
+        "partial",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "distributive": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=",
+      "dependencies": [
+        "identity",
+        "newtype",
+        "prelude",
+        "tuples",
+        "type-equality"
+      ]
+    },
+    "effect": {
+      "type": "registry",
+      "version": "4.0.0",
+      "integrity": "sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=",
+      "dependencies": [
+        "prelude"
+      ]
+    },
+    "either": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=",
+      "dependencies": [
+        "control",
+        "invariant",
+        "maybe",
+        "prelude"
+      ]
+    },
+    "enums": {
+      "type": "registry",
+      "version": "6.0.1",
+      "integrity": "sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=",
+      "dependencies": [
+        "control",
+        "either",
+        "gen",
+        "maybe",
+        "newtype",
+        "nonempty",
+        "partial",
+        "prelude",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "exceptions": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-K0T89IHtF3vBY7eSAO7eDOqSb2J9kZGAcDN5+IKsF8E=",
+      "dependencies": [
+        "effect",
+        "either",
+        "maybe",
+        "prelude"
+      ]
+    },
+    "exists": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=",
+      "dependencies": [
+        "unsafe-coerce"
+      ]
+    },
+    "foldable-traversable": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=",
+      "dependencies": [
+        "bifunctors",
+        "const",
+        "control",
+        "either",
+        "functors",
+        "identity",
+        "maybe",
+        "newtype",
+        "orders",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "fork": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-X7u0SuCvFbLbzuNEKLBNuWjmcroqMqit4xEzpQwAP7E=",
+      "dependencies": [
+        "aff"
+      ]
+    },
+    "free": {
+      "type": "registry",
+      "version": "7.1.0",
+      "integrity": "sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=",
+      "dependencies": [
+        "catenable-lists",
+        "control",
+        "distributive",
+        "either",
+        "exists",
+        "foldable-traversable",
+        "invariant",
+        "lazy",
+        "maybe",
+        "prelude",
+        "tailrec",
+        "transformers",
+        "tuples",
+        "unsafe-coerce"
+      ]
+    },
+    "functions": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=",
+      "dependencies": [
+        "prelude"
+      ]
+    },
+    "functors": {
+      "type": "registry",
+      "version": "5.0.0",
+      "integrity": "sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=",
+      "dependencies": [
+        "bifunctors",
+        "const",
+        "contravariant",
+        "control",
+        "distributive",
+        "either",
+        "invariant",
+        "maybe",
+        "newtype",
+        "prelude",
+        "profunctor",
+        "tuples",
+        "unsafe-coerce"
+      ]
+    },
+    "gen": {
+      "type": "registry",
+      "version": "4.0.0",
+      "integrity": "sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=",
+      "dependencies": [
+        "either",
+        "foldable-traversable",
+        "identity",
+        "maybe",
+        "newtype",
+        "nonempty",
+        "prelude",
+        "tailrec",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "identity": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=",
+      "dependencies": [
+        "control",
+        "invariant",
+        "newtype",
+        "prelude"
+      ]
+    },
+    "integers": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=",
+      "dependencies": [
+        "maybe",
+        "numbers",
+        "prelude"
+      ]
+    },
+    "invariant": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=",
+      "dependencies": [
+        "control",
+        "prelude"
+      ]
+    },
+    "lazy": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=",
+      "dependencies": [
+        "control",
+        "foldable-traversable",
+        "invariant",
+        "prelude"
+      ]
+    },
+    "lists": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=",
+      "dependencies": [
+        "bifunctors",
+        "control",
+        "foldable-traversable",
+        "lazy",
+        "maybe",
+        "newtype",
+        "nonempty",
+        "partial",
+        "prelude",
+        "tailrec",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "maybe": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=",
+      "dependencies": [
+        "control",
+        "invariant",
+        "newtype",
+        "prelude"
+      ]
+    },
+    "mmorph": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-urZlZNNqGeQFe5D/ClHlR8QgGBNHTMFPtJ5S5IpflTQ=",
+      "dependencies": [
+        "free",
+        "functors",
+        "transformers"
+      ]
+    },
+    "newtype": {
+      "type": "registry",
+      "version": "5.0.0",
+      "integrity": "sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=",
+      "dependencies": [
+        "prelude",
+        "safe-coerce"
+      ]
+    },
+    "node-buffer": {
+      "type": "registry",
+      "version": "9.0.0",
+      "integrity": "sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=",
+      "dependencies": [
+        "arraybuffer-types",
+        "effect",
+        "maybe",
+        "nullable",
+        "st",
+        "unsafe-coerce"
+      ]
+    },
+    "node-event-emitter": {
+      "type": "registry",
+      "version": "3.0.0",
+      "integrity": "sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=",
+      "dependencies": [
+        "effect",
+        "either",
+        "functions",
+        "maybe",
+        "nullable",
+        "prelude",
+        "unsafe-coerce"
+      ]
+    },
+    "nonempty": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=",
+      "dependencies": [
+        "control",
+        "foldable-traversable",
+        "maybe",
+        "prelude",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "now": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=",
+      "dependencies": [
+        "datetime",
+        "effect"
+      ]
+    },
+    "nullable": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=",
+      "dependencies": [
+        "effect",
+        "functions",
+        "maybe"
+      ]
+    },
+    "numbers": {
+      "type": "registry",
+      "version": "9.0.1",
+      "integrity": "sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=",
+      "dependencies": [
+        "functions",
+        "maybe"
+      ]
+    },
+    "ordered-collections": {
+      "type": "registry",
+      "version": "3.2.0",
+      "integrity": "sha256-o9jqsj5rpJmMdoe/zyufWHFjYYFTTsJpgcuCnqCO6PM=",
+      "dependencies": [
+        "arrays",
+        "foldable-traversable",
+        "gen",
+        "lists",
+        "maybe",
+        "partial",
+        "prelude",
+        "st",
+        "tailrec",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "orders": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=",
+      "dependencies": [
+        "newtype",
+        "prelude"
+      ]
+    },
+    "parallel": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=",
+      "dependencies": [
+        "control",
+        "effect",
+        "either",
+        "foldable-traversable",
+        "functors",
+        "maybe",
+        "newtype",
+        "prelude",
+        "profunctor",
+        "refs",
+        "transformers"
+      ]
+    },
+    "partial": {
+      "type": "registry",
+      "version": "4.0.0",
+      "integrity": "sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=",
+      "dependencies": []
+    },
+    "pipes": {
+      "type": "registry",
+      "version": "8.0.0",
+      "integrity": "sha256-kvfqGM4cPA/wCcBHbp5psouFw5dZGvku2462x7ZBwSY=",
+      "dependencies": [
+        "aff",
+        "lists",
+        "mmorph",
+        "prelude",
+        "tailrec",
+        "transformers",
+        "tuples"
+      ]
+    },
+    "prelude": {
+      "type": "registry",
+      "version": "6.0.1",
+      "integrity": "sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=",
+      "dependencies": []
+    },
+    "profunctor": {
+      "type": "registry",
+      "version": "6.0.1",
+      "integrity": "sha256-E58hSYdJvF2Qjf9dnWLPlJKh2Z2fLfFLkQoYi16vsFk=",
+      "dependencies": [
+        "control",
+        "distributive",
+        "either",
+        "exists",
+        "invariant",
+        "newtype",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "refs": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=",
+      "dependencies": [
+        "effect",
+        "prelude"
+      ]
+    },
+    "safe-coerce": {
+      "type": "registry",
+      "version": "2.0.0",
+      "integrity": "sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=",
+      "dependencies": [
+        "unsafe-coerce"
+      ]
+    },
+    "spec": {
+      "type": "registry",
+      "version": "8.1.0",
+      "integrity": "sha256-kylPL0sBujW9w8yk+bguI92BiUuiyosPWyp/TTqPURw=",
+      "dependencies": [
+        "aff",
+        "ansi",
+        "arrays",
+        "avar",
+        "bifunctors",
+        "control",
+        "datetime",
+        "effect",
+        "either",
+        "exceptions",
+        "foldable-traversable",
+        "fork",
+        "identity",
+        "integers",
+        "lists",
+        "maybe",
+        "newtype",
+        "now",
+        "ordered-collections",
+        "parallel",
+        "pipes",
+        "prelude",
+        "refs",
+        "strings",
+        "tailrec",
+        "transformers",
+        "tuples"
+      ]
+    },
+    "st": {
+      "type": "registry",
+      "version": "6.2.0",
+      "integrity": "sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=",
+      "dependencies": [
+        "partial",
+        "prelude",
+        "tailrec",
+        "unsafe-coerce"
+      ]
+    },
+    "strings": {
+      "type": "registry",
+      "version": "6.0.1",
+      "integrity": "sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=",
+      "dependencies": [
+        "arrays",
+        "control",
+        "either",
+        "enums",
+        "foldable-traversable",
+        "gen",
+        "integers",
+        "maybe",
+        "newtype",
+        "nonempty",
+        "partial",
+        "prelude",
+        "tailrec",
+        "tuples",
+        "unfoldable",
+        "unsafe-coerce"
+      ]
+    },
+    "tailrec": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=",
+      "dependencies": [
+        "bifunctors",
+        "effect",
+        "either",
+        "identity",
+        "maybe",
+        "partial",
+        "prelude",
+        "refs"
+      ]
+    },
+    "transformers": {
+      "type": "registry",
+      "version": "6.1.0",
+      "integrity": "sha256-3Bm+Z6tsC/paG888XkywDngJ2JMos+JfOhRlkVfb7gI=",
+      "dependencies": [
+        "control",
+        "distributive",
+        "effect",
+        "either",
+        "exceptions",
+        "foldable-traversable",
+        "identity",
+        "lazy",
+        "maybe",
+        "newtype",
+        "prelude",
+        "st",
+        "tailrec",
+        "tuples",
+        "unfoldable"
+      ]
+    },
+    "tuples": {
+      "type": "registry",
+      "version": "7.0.0",
+      "integrity": "sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=",
+      "dependencies": [
+        "control",
+        "invariant",
+        "prelude"
+      ]
+    },
+    "type-equality": {
+      "type": "registry",
+      "version": "4.0.1",
+      "integrity": "sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=",
+      "dependencies": []
+    },
+    "unfoldable": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=",
+      "dependencies": [
+        "foldable-traversable",
+        "maybe",
+        "partial",
+        "prelude",
+        "tuples"
+      ]
+    },
+    "unsafe-coerce": {
+      "type": "registry",
+      "version": "6.0.0",
+      "integrity": "sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=",
+      "dependencies": []
+    }
+  }
+}

--- a/spago.yaml
+++ b/spago.yaml
@@ -14,7 +14,7 @@ package:
     - nullable: ">=6.0.0 <7.0.0"
     - prelude: ">=6.0.0 <7.0.0"
     - node-event-emitter: ">=3.0.0 <4.0.0"
-    - aff: ">=8.0.0 <9.0.0"
+    - aff: ">=7.0.0 <9.0.0"
   test:
     main: Test.Main
     # See also other tests


### PR DESCRIPTION
Because spec test dependency needs aff <8.0.0

Also `spago.lock` format changed from YAML to JSON.