### PR TITLE
Keep major version 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,11 @@ Bugfixes:
 
 Other improvements:
 
-## [v10.0.0](https://github.com/purescript-node/purescript-node-streams/releases/tag/v10.0.0) - 2024-09-27
-
-Breaking changes:
-
-- Upgrade dependency `aff`. #57
+## [v9.0.1](https://github.com/purescript-node/purescript-node-streams/releases/tag/v10.0.0) - 2024-09-27
 
 Other improvements:
 
+- Upgrade dependency `aff`. #57
 - Change build system from `bower` to `spago`. #57
 
 ## [v9.0.0](https://github.com/purescript-node/purescript-node-streams/releases/tag/v9.0.0) - 2022-07-26


### PR DESCRIPTION
Because actually we did not bump the major version requirement for aff.

aff version requirement has changed from `>=7.0.0 <8.0.0` to `>=7.0.0 <9.0.0`