### PR TITLE
Correct version in spago.yaml

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -2,7 +2,7 @@ package:
   name: node-streams
   publish:
     license: MIT
-    version: 10.0.0
+    version: 9.0.1
     location:
       githubOwner: purescript-node
       githubRepo: purescript-node-streams


### PR DESCRIPTION
It was still 10.0.0.